### PR TITLE
Add /embed handling for H5P iframe URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ The following new directives are provided:
 ```
 ````
 
-In case of a YouTube-link, it is inverted to an embed link if the normal web URL is provided.
+In case of a YouTube-link, it is inverted to an embed link if the normal web URL is provided. H5p links are converted too if provided without `/embed`.
 
 ````md
 ```{iframe-figure} <link_to_webpage_to_embed>

--- a/src/sphinx_iframes/__init__.py
+++ b/src/sphinx_iframes/__init__.py
@@ -153,6 +153,13 @@ def generate_iframe_html(source):
 
         url = base_video+'?'+options
 
+    # Handle H5P URLs - add /embed if not present
+    if source.name == 'h5p':
+        if '/embed' not in url and url.endswith('/'):
+            url = url + 'embed'
+        elif '/embed' not in url and not url.endswith('/'):
+            url = url + '/embed'
+
     if source.name == "video":
         if add_user:
             iframe_html = '<div class="video-container user" %s>\n'%(style)


### PR DESCRIPTION
Updates the generate_iframe_html function to append '/embed' to H5P URLs if not already present, ensuring correct embedding behavior for H5P content.