### PR TITLE
Metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ This extension provides several Sphinx directives:
 - `h5p`
 - `video`
 - `iframe-figure`
+- `video-figure`
+- `h5p-figure`
 
  that can be used to quickly insert an iframe with standard sizing and styling.
 
@@ -127,6 +129,22 @@ The caption for the iframe.
 ```
 ````
 
+````md
+```{h5p-figure} <link_to_h5p_webpage_to_embed>
+:name: some:label
+
+The caption for the h5p webpage.
+```
+````
+
+````md
+```{video-figure} <link_to_video_to_embed>
+:name: some:label
+
+The caption for the video.
+```
+````
+
 Note that you don't need the full embed code of an iframe. Only the source url should be used.
 
 All of these have the following options:
@@ -152,7 +170,14 @@ All of these have the following options:
 
 For the directive `video`, if a direct link to a video file is given, then only the options from the `video` directive from [sphinxcontrib.video](https://sphinxcontrib-video.readthedocs.io/en/latest/quickstart.html) should be used. For any other link, the options above should be used.
 
-The directive `iframe-figure` also inherits all options from the `figure` directive from Sphinx.
+The directives `iframe-figure`, `video-figure` and `h5p-figure` also inherit all options from the `figure` directive from the extension `sphinx_metadata_figure`.
+
+## Metadata
+
+The `iframe-figure`, `video-figure` and `h5p-figure` directives use the `figure` directive from the `sphinx_metadata_figure` extension to add metadata to the figures they create. This metadata can include information such as author, license, copyright, and source. This information is useful for documentation and attribution purposes.
+
+> [!NOTE]
+> This extension always loads the extension `sphinx_metadata_figure` as it depends on it to add metadata to the figures. This means that also the configuration options of that extension are available and if this is not desired, you must disable the workings of that extensions by applying appropriate settings in `metadata_figure_settings` in your Sphinx configuration file. See the [documentation](https://teachbooks.io/manual/_git/github.com_TeachBooks_Sphinx-Metadata-Figure/main/MANUAL.html) of the `sphinx_metadata_figure` extension for more information.
 
 ## Examples and details
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ authors = [
 dependencies = [
     "sphinx",
     "sphinxcontrib-video",
-    "sphinx-metadata-figure>=v1.0.3"
+    "sphinx-metadata-figure>=v1.1.1"
 ]
 
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,8 @@ authors = [
 ]
 dependencies = [
     "sphinx",
-    "sphinxcontrib-video"
+    "sphinxcontrib-video",
+    "sphinx-metadata-figure>=v1.0.3"
 ]
 
 requires-python = ">=3.10"

--- a/src/sphinx_iframes/__init__.py
+++ b/src/sphinx_iframes/__init__.py
@@ -65,7 +65,7 @@ class IframeDirective(SphinxDirective):
         assert self.arguments[0] is not None
 
         # discriminate between mp4, webm, ogg and other urls for the video directive
-        if self.name == "video":
+        if self.name in ["video","video-figure"]:
             if self.arguments[0].lower().endswith('.mp4') or self.arguments[0].lower().endswith('.webm') or self.arguments[0].lower().endswith('.ogg'):
                 video_directive = Video(
                     self.name,
@@ -105,12 +105,12 @@ def generate_iframe_html(source):
         div_class = ""
     iframe_class = source.options.get("class")
 
-    if source.name == "h5p":
+    if source.name in ["h5p","h5p-figure"]:
         base_class = "sphinx h5p blend"
         if iframe_class is not None:
             if "no-blend" in iframe_class:
                 base_class = "sphinx h5p"        
-    elif source.name == "video":
+    elif source.name in ["video","video-figure"]:
         base_class = "sphinx video no-blend"
         if iframe_class is not None:
             if "blend" in iframe_class and "not-blend" not in iframe_class:
@@ -125,7 +125,7 @@ def generate_iframe_html(source):
     else:
         iframe_class = base_class+""+str(iframe_class)
     
-    if source.name == 'h5p':
+    if source.name in ["h5p","h5p-figure"]:
         style = generate_style(
             None, None,"auto",None
         )
@@ -171,6 +171,8 @@ def generate_iframe_html(source):
             options = ';'.join(options)
 
             url = 'https://www.youtube.com/embed/'+video+'?'+options
+        elif 'watch/' in url:
+            url = url.replace('watch/','embed/')
     if 'youtu.be' in url:
         tail = url[1+url.find('?'):]
         list_index = tail.find('list=PL')
@@ -200,13 +202,13 @@ def generate_iframe_html(source):
         url = base_video+'?'+options
 
     # Handle H5P URLs - add /embed if not present
-    if source.name == 'h5p':
+    if source.name in ["h5p","h5p-figure"]:
         if '/embed' not in url and url.endswith('/'):
             url = url + 'embed'
         elif '/embed' not in url and not url.endswith('/'):
             url = url + '/embed'
 
-    if source.name == "video":
+    if source.name in ["video","video-figure"]:
         if add_user:
             iframe_html = '<div class="video-container user %s" %s>\n'%(div_class, style)
         else:
@@ -215,7 +217,7 @@ def generate_iframe_html(source):
             <iframe class="{iframe_class}" {frame_style} src="{url}" allow="fullscreen *;autoplay *; geolocation *; microphone *; camera *; midi *; encrypted-media *" frameborder="0"></iframe>
         """
         iframe_html += '\n</div>'
-    elif source.name == 'h5p':
+    elif source.name in ["h5p","h5p-figure"]:
         if add_user:
             iframe_html = '<div class="iframe-container user %s" %s>\n'%(div_class, style)
         else:


### PR DESCRIPTION
This pull request adds new figure-based directives for embedding videos and H5P content in Sphinx documentation, and integrates support for metadata in these figures via the `sphinx_metadata_figure` extension. It updates both the implementation and documentation to reflect these enhancements, and ensures that metadata can be flexibly placed in figure captions, admonitions, or margins.

**New directives and metadata support:**

* Added new directives: `video-figure` and `h5p-figure`, which allow embedding videos and H5P content as figures with metadata support. These directives, along with `iframe-figure`, inherit options from the `figure` directive of the `sphinx_metadata_figure` extension. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R16-R17) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R132-R147) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L155-R180) [[4]](diffhunk://#diff-98b885e7094824bdfcad2568ee2f0c997fc405a8fc51f89b92d2b6c6bd4e63b9R252-R259)
* Updated the implementation so that `IframeFigure` now subclasses `MetadataFigure` instead of `Figure`, enabling metadata handling for these new directives.

**Integration and dependency changes:**

* Added `sphinx-metadata-figure` as a required dependency in `pyproject.toml` and ensured it is loaded by default in the Sphinx extension setup. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L16-R17) [[2]](diffhunk://#diff-98b885e7094824bdfcad2568ee2f0c997fc405a8fc51f89b92d2b6c6bd4e63b9R252-R259)

**Directive logic and rendering improvements:**

* Updated logic throughout `src/sphinx_iframes/__init__.py` to handle the new directives (`video-figure`, `h5p-figure`) in all relevant places, including iframe HTML generation and URL handling. [[1]](diffhunk://#diff-98b885e7094824bdfcad2568ee2f0c997fc405a8fc51f89b92d2b6c6bd4e63b9R15) [[2]](diffhunk://#diff-98b885e7094824bdfcad2568ee2f0c997fc405a8fc51f89b92d2b6c6bd4e63b9L67-R68) [[3]](diffhunk://#diff-98b885e7094824bdfcad2568ee2f0c997fc405a8fc51f89b92d2b6c6bd4e63b9L107-R113) [[4]](diffhunk://#diff-98b885e7094824bdfcad2568ee2f0c997fc405a8fc51f89b92d2b6c6bd4e63b9L127-R128) [[5]](diffhunk://#diff-98b885e7094824bdfcad2568ee2f0c997fc405a8fc51f89b92d2b6c6bd4e63b9R174-R175) [[6]](diffhunk://#diff-98b885e7094824bdfcad2568ee2f0c997fc405a8fc51f89b92d2b6c6bd4e63b9L202-R211) [[7]](diffhunk://#diff-98b885e7094824bdfcad2568ee2f0c997fc405a8fc51f89b92d2b6c6bd4e63b9L217-R220)
* Enhanced the `IframeFigure` directive to support configurable placement of metadata (caption, admonition, margin, or hidden) based on Sphinx configuration, providing flexible output for documentation needs.